### PR TITLE
Update text FormField to be optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IDE stuff
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # IDE stuff
 .vscode
+
+# OSX stuff
+.DS_Store

--- a/slack_utils/forms.py
+++ b/slack_utils/forms.py
@@ -12,6 +12,6 @@ class CommandForm(forms.Form):
     user_id = forms.CharField()
     user_name = forms.CharField()
     command = forms.CharField()
-    text = forms.CharField()
+    text = forms.CharField(required=False)
     response_url = forms.URLField()
     trigger_id = forms.CharField()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -149,3 +149,30 @@ class CommandViewCase(TestCase):
 
         finally:
             registry.clear()
+
+    def test_slash_command_without_text(self):
+        factory = RequestFactory()
+        request = factory.post(
+            "/path",
+            dict(
+                token="token",
+                team_id="team_id",
+                team_domain="team_domain",
+                enterprise_id="enterprise_id",
+                enterprise_name="enterprise_name",
+                channel_id="channel_id",
+                channel_name="channel_name",
+                user_id="user_id",
+                user_name="user_name",
+                command="command_without_text",
+                response_url="http://responseurl.com/path",
+                trigger_id="trigger_id",
+            ),
+        )
+
+        with mock.patch("slack_utils.decorators.verify_request", return_value=True):
+            view = CommandView()
+            with mock.patch("slack_utils.views.registry") as registry_mock:
+                registry_mock.register("command_without_text", lambda: None)
+                resp = view.post(request)
+        self.assertEqual(resp.status_code, 200, resp.content)


### PR DESCRIPTION
## Problem
Currently the text field is required. This results in bad request for slash commands without arguments.

## Proposed Solution
This commit marks it as optional so that standalone slash commands work without error.

## Related Issue
Issue #4 


_Note: Updated gitignore file to ignore IDE related files._