### PR TITLE
Upgrade to work with modern django

### DIFF
--- a/slack_utils/signals.py
+++ b/slack_utils/signals.py
@@ -1,3 +1,3 @@
 import django.dispatch
 
-event_received = django.dispatch.Signal(providing_args=["event_type", "event_data"])
+event_received = django.dispatch.Signal()

--- a/slack_utils/urls.py
+++ b/slack_utils/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import include, re_path
 
 from slack_utils import views
 
 urlpatterns = [
-    url('events/$', views.EventsView.as_view(), name='slack-events-api'),
-    url('commands/$', views.CommandView.as_view(), name='slack-commands'),
+    re_path('events/$', views.EventsView.as_view(), name='slack-events-api'),
+    re_path('commands/$', views.CommandView.as_view(), name='slack-commands'),
 ]


### PR DESCRIPTION
Upgrade to work with Django 4+

* Change url() to re_path in urls.py
* Remove providing_args in signals.py
* This pull requests drops support for older versions of django.

